### PR TITLE
Got this:

### DIFF
--- a/src/fabtools/recipes/graphite/__init__.py
+++ b/src/fabtools/recipes/graphite/__init__.py
@@ -44,7 +44,7 @@ def install_graphite(target_dir='/opt/graphite', local_port=6000,
             'django-tagging',
             'gunicorn',
             'simplejson',
-        ], virtualenv=target_dir)
+        ])
 
         # Require a recent libcairo
         require.deb.ppa('ppa:xorg-edgers/ppa')


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/fabric/main.py", line 712, in main
    _args, *_kwargs
  File "/usr/local/lib/python2.7/dist-packages/fabric/tasks.py", line 327, in execute
    results['<local-only>'] = task.run(_args, *_new_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/fabric/tasks.py", line 112, in run
    return self.wrapped(_args, *_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/fabtools.recipes.graphite-0.1-py2.7.egg/fabtools/recipes/graphite/**init**.py", line 47, in install_graphite
    ], virtualenv=target_dir)
TypeError: packages() got an unexpected keyword argument 'virtualenv'

This simple modification made it pass, not sure it's the right fix
